### PR TITLE
Workflow only on sudays

### DIFF
--- a/pipeline/Tickets.json
+++ b/pipeline/Tickets.json
@@ -1239,7 +1239,7 @@
 				]
 			},
 			{
-				"name": "Copy CAPEX NFDs",
+				"name": "Extract CAPEX",
 				"description": "Copy NFD tickets to REQUESTIA_CAPEXNFD table, solving timeout in Microsoft Flow that send weekly mail from sergio.queiroz@opty.com.br account",
 				"type": "SqlServerStoredProcedure",
 				"dependsOn": [
@@ -1260,6 +1260,34 @@
 				"userProperties": [],
 				"typeProperties": {
 					"storedProcedureName": "[dbo].[sp_EXTRACTCAPEXREQUESTS]"
+				},
+				"linkedServiceName": {
+					"referenceName": "AzureSQL_DB_Procedimentos",
+					"type": "LinkedServiceReference"
+				}
+			},
+			{
+				"name": "Extract TISS",
+				"description": "Copy TISS tickets to specific table, solving timeout in Microsoft Flow that send weekly mail from sergio.queiroz@opty.com.br account",
+				"type": "SqlServerStoredProcedure",
+				"dependsOn": [
+					{
+						"activity": "Update clients",
+						"dependencyConditions": [
+							"Succeeded"
+						]
+					}
+				],
+				"policy": {
+					"timeout": "7.00:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"storedProcedureName": "[dbo].[sp_EXTRACTTISSREQUESTS]"
 				},
 				"linkedServiceName": {
 					"referenceName": "AzureSQL_DB_Procedimentos",


### PR DESCRIPTION
Adjust stored procedures sp_EXTRACTCAPEX and SP_EXTRACTTISS to runs only on Sundays, saving execution time on whole pipeline. Their specific tables are used on Microsoft Flow on sergio.queiroz@opty.com.br account.